### PR TITLE
Explicitly add openmp implementation.

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+channels:
+  - build

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-channels:
-  - build

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,7 @@ source:
     - patches/fix_find_python_stuff.patch
 
 build:
-  number: 0
+  number: 1
 
 outputs:
   - name: zfp
@@ -36,9 +36,14 @@ outputs:
         - make     # [unix]
         # For defaults, this is included in libgcc-ng
         # - libgomp  # [linux]
+      host:
+        - libgomp      # [linux]
         - llvm-openmp  # [osx]
+        - vcomp14      # [win and x86_64]
       run:
-        - _openmp_mutex  # [linux]
+        - libgomp      # [linux]
+        - llvm-openmp  # [osx]
+        - vcomp14      # [win and x86_64]
     test:
       commands:
         - test -f $PREFIX/include/zfp.h                # [unix]
@@ -73,10 +78,16 @@ outputs:
         - numpy {{ numpy }}
         - cython >=0.28
         - {{ pin_subpackage('zfp', exact=True) }}
+        - libgomp      # [linux]
+        - llvm-openmp  # [osx]
+        - vcomp14      # [win and x86_64]
       run:
         - python
         - numpy >=1.8.0
         - {{ pin_subpackage('zfp', exact=True) }}
+        - libgomp      # [linux]
+        - llvm-openmp  # [osx]
+        - vcomp14      # [win and x86_64]
     test:
       imports:
         - zfpy


### PR DESCRIPTION
zfpy openmp rebuild

**Destination channel:** defaults

### Links

- [PKG-14738](https://anaconda.atlassian.net/browse/PKG-14738) 

### Explanation of changes:

- Bump build number
- Explicitly pin openmp_impl being used

## Note
The Github UI didn't update, the graph is green: https://package-build.anaconda.com/v1/graph/b83f1520-0784-4f77-88ba-41fe376db7f8

[OpenMP usage Audit](https://docs.google.com/spreadsheets/d/1Pln3E1WKlhasfR5NNyT9juhXrcM_63bQpAZRHDjNHtc/edit?usp=sharing)


[PKG-14738]: https://anaconda.atlassian.net/browse/PKG-14738?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ